### PR TITLE
C2kle/pending resolver entity

### DIFF
--- a/src/entities/AvianDietPending.ts
+++ b/src/entities/AvianDietPending.ts
@@ -4,7 +4,7 @@ import { BaseEntity, Column, Entity, PrimaryGeneratedColumn } from "typeorm";
 @ObjectType()
 @Entity()
 export class AvianDietPending extends BaseEntity {
-    //@Field()
+    @Field()
     @PrimaryGeneratedColumn()
     unique_id: number;
 
@@ -12,7 +12,7 @@ export class AvianDietPending extends BaseEntity {
     @Column()
     common_name: string;
 
-    //@Field({ nullable: true })
+    @Field({ nullable: true })
     @Column({ nullable: true })
     scientific_name: string;
 
@@ -20,7 +20,7 @@ export class AvianDietPending extends BaseEntity {
     @Column({ nullable: true })
     subspecies: string;
 
-    //@Field({ nullable: true })
+    @Field({ nullable: true })
     @Column({ nullable: true })
     family: string;
 
@@ -28,23 +28,23 @@ export class AvianDietPending extends BaseEntity {
     @Column({ nullable: true })
     taxonomy: string;
 
-    //@Field({ nullable: true })
+    @Field({ nullable: true })
     @Column({ nullable: true })
     longitude_dd: string;
 
-    //@Field({ nullable: true })
+    @Field({ nullable: true })
     @Column({ nullable: true })
     latitude_dd: string;
 
-    //@Field({ nullable: true })
+    @Field({ nullable: true })
     @Column({ nullable: true })
     altitude_min_m: string;
 
-    //@Field({ nullable: true })
+    @Field({ nullable: true })
     @Column({ nullable: true })
     altitude_max_m: string;
 
-    //@Field({ nullable: true })
+    @Field({ nullable: true })
     @Column({ nullable: true })
     altitude_mean_m: string;
 
@@ -56,31 +56,31 @@ export class AvianDietPending extends BaseEntity {
     @Column({ nullable: true })
     location_specific: string;
 
-    //@Field({ nullable: true })
+    @Field({ nullable: true })
     @Column({ nullable: true })
     habitat_type: string;
 
-    //@Field({ nullable: true })
+    @Field({ nullable: true })
     @Column({ nullable: true })
     observation_month_begin: number;
 
-    //@Field({ nullable: true })
+    @Field({ nullable: true })
     @Column({ nullable: true })
     observation_month_end: number;
 
-    //@Field({ nullable: true })
+    @Field({ nullable: true })
     @Column({ nullable: true })
     observation_year_begin: number;
 
-    //@Field({ nullable: true })
+    @Field({ nullable: true })
     @Column({ nullable: true })
     observation_year_end: number;
 
-    //@Field({ nullable: true })
+    @Field({ nullable: true })
     @Column({ nullable: true })
     observation_season: string;
 
-    //@Field({ nullable: true })
+    @Field({ nullable: true })
     @Column({ nullable: true })
     analysis_number: string;
 
@@ -88,59 +88,59 @@ export class AvianDietPending extends BaseEntity {
     @Column()
     prey_kingdom: string;
 
-    //@Field({ nullable: true })
+    @Field({ nullable: true })
     @Column({ nullable: true })
     prey_phylum: string;
 
-    //@Field({ nullable: true })
+    @Field({ nullable: true })
     @Column({ nullable: true })
     prey_class: string;
 
-    //@Field({ nullable: true })
+    @Field({ nullable: true })
     @Column({ nullable: true })
     prey_order: string;
 
-    //@Field({ nullable: true })
+    @Field({ nullable: true })
     @Column({ nullable: true })
     prey_suborder: string;
 
-    //@Field({ nullable: true })
+    @Field({ nullable: true })
     @Column({ nullable: true })
     prey_family: string;
 
-    //@Field({ nullable: true })
+    @Field({ nullable: true })
     @Column({ nullable: true })
     prey_genus: string;
 
-    //@Field({ nullable: true })
+    @Field({ nullable: true })
     @Column({ nullable: true })
     prey_scientific_name: string;
 
-    //@Field({ nullable: true })
+    @Field({ nullable: true })
     @Column({ nullable: true })
     inclusive_prey_taxon: string;
 
-    //@Field({ nullable: true })
+    @Field({ nullable: true })
     @Column({ nullable: true })
     prey_name_ITIS_ID: string;
 
-    //@Field({ nullable: true })
+    @Field({ nullable: true })
     @Column({ nullable: true })
     prey_name_status: string;
 
-    //@Field({ nullable: true })
+    @Field({ nullable: true })
     @Column({ nullable: true })
     prey_stage: string;
 
-    //@Field({ nullable: true })
+    @Field({ nullable: true })
     @Column({ nullable: true })
     prey_part: string;
 
-    //@Field({ nullable: true })
+    @Field({ nullable: true })
     @Column({ nullable: true })
     prey_common_name: string;
 
-    //@Field({ nullable: true })
+    @Field({ nullable: true })
     @Column({ nullable: true })
     fraction_diet: string;
 
@@ -148,31 +148,89 @@ export class AvianDietPending extends BaseEntity {
     @Column()
     diet_type: string;
 
-    //@Field({ nullable: true })
+    @Field({ nullable: true })
     @Column({ nullable: true })
     item_sample_size: number;
 
-    //@Field({ nullable: true })
+    @Field({ nullable: true })
     @Column({ nullable: true })
     bird_sample_size: number;
 
-    //@Field({ nullable: true })
+    @Field({ nullable: true })
     @Column({ nullable: true })
     sites: string;
 
-    //@Field({ nullable: true })
+    @Field({ nullable: true })
     @Column({ nullable: true })
     study_type: string;
 
-    //@Field({ nullable: true })
+    @Field({ nullable: true })
     @Column({ length: 500, nullable: true })
     notes: string;
 
-    //@Field({ nullable: true })
+    @Field({ nullable: true })
     @Column({ nullable: true })
     entered_by: string;
 
     @Field()
     @Column({ length: 500 })
     source: string;
+
+    //Spring 2021 additional columns
+    @Field()
+    @Column({ nullable: true })
+    doi: string;
+
+    @Field()
+    @Column({ nullable: true })
+    species: string;
+
+    @Field()
+    @Column({ nullable: true })
+    new_species: string;
+
+    @Field()
+    @Column({ nullable: true })
+    country: string;
+
+    @Field()
+    @Column({ nullable: true })
+    state_province: string;
+
+    @Field()
+    @Column({ nullable: true })
+    location_other: string;
+
+    @Field()
+    @Column({ nullable: true })
+    lat_long_yn: string;
+
+    @Field()
+    @Column({ nullable: true })
+    elevation_yn: string;
+
+    @Field()
+    @Column({ nullable: true })
+    sex_yn: string;
+
+    @Field()
+    @Column({ nullable: true })
+    sex: string;
+
+    @Field()
+    @Column({ nullable: true })
+    age_class: string;
+
+    @Field()
+    @Column({ nullable: true })
+    study_location: string;
+
+    @Field()
+    @Column({ nullable: true })
+    table_fig_number: string;
+
+    @Field()
+    @Column({ nullable: true })
+    all_prey_diet_yn: string;
+
 }

--- a/src/entities/AvianDietPending.ts
+++ b/src/entities/AvianDietPending.ts
@@ -177,59 +177,59 @@ export class AvianDietPending extends BaseEntity {
     source: string;
 
     //Spring 2021 additional columns
-    @Field()
+    @Field({ nullable: true })
     @Column({ nullable: true })
     doi: string;
 
-    @Field()
+    @Field({ nullable: true })
     @Column({ nullable: true })
     species: string;
 
-    @Field()
+    @Field({ nullable: true })
     @Column({ nullable: true })
     new_species: string;
 
-    @Field()
+    @Field({ nullable: true })
     @Column({ nullable: true })
     country: string;
 
-    @Field()
+    @Field({ nullable: true })
     @Column({ nullable: true })
     state_province: string;
 
-    @Field()
+    @Field({ nullable: true })
     @Column({ nullable: true })
     location_other: string;
 
-    @Field()
+    @Field({ nullable: true })
     @Column({ nullable: true })
     lat_long_yn: string;
 
-    @Field()
+    @Field({ nullable: true })
     @Column({ nullable: true })
     elevation_yn: string;
 
-    @Field()
+    @Field({ nullable: true })
     @Column({ nullable: true })
     sex_yn: string;
 
-    @Field()
+    @Field({ nullable: true })
     @Column({ nullable: true })
     sex: string;
 
-    @Field()
+    @Field({ nullable: true })
     @Column({ nullable: true })
     age_class: string;
 
-    @Field()
+    @Field({ nullable: true })
     @Column({ nullable: true })
     study_location: string;
 
-    @Field()
+    @Field({ nullable: true })
     @Column({ nullable: true })
     table_fig_number: string;
 
-    @Field()
+    @Field({ nullable: true })
     @Column({ nullable: true })
     all_prey_diet_yn: string;
 

--- a/src/resolvers/PendingPageResolver.ts
+++ b/src/resolvers/PendingPageResolver.ts
@@ -1,8 +1,8 @@
 import { AvianDietPending } from "../entities/AvianDietPending";
 import { AvianDiet } from "../entities/AvianDiet";
-import {Field, Query, Resolver, InputType, Mutation,Arg } from "type-graphql";
+import {Field, Query, Resolver, InputType, Mutation,Arg, Int } from "type-graphql";
 
-
+//need to figure out how to use either inputType or Argstype on frontend so we don't have to write out arguments every time
 @InputType()
 class PendingDietInput {
     @Field()
@@ -37,25 +37,95 @@ export class PendingPageResolver {
         return AvianDietPending.find();
     }
 
+    //we will use this function once we figure things out
     @Mutation(() => AvianDietPending) 
     async createPendingDiet(@Arg("input", () => PendingDietInput) input: PendingDietInput) {
         const pendingDiet = await AvianDietPending.create(input).save();
         return pendingDiet;
     }
 
+    //we are using this function because it works with frontend but eww
     @Mutation(() => Boolean)
     async createAlternativePendingDiet(
+        //add common_name
         @Arg("common_name", () => String) common_name: string,
-        @Arg("source", () => String) source: string,
+
+        //add scientific_name
+        @Arg("scientific_name", () => String) scientific_name: string,
+
         @Arg("subspecies", () => String) subspecies: string,
+
+        //add family
+        @Arg("family", () => String) family: string,
+
         @Arg("taxonomy", () => String) taxonomy: string,
+        @Arg("longitude_dd", () => String) longitude_dd: string,
+        @Arg("latitude_dd", () => String) latitude_dd: string,
+        @Arg("altitude_min_m", () => String) altitude_min_m: string,
+        @Arg("altitude_max_m", () => String) altitude_max_m: string,
+        @Arg("altitude_mean_m", () => String) altitude_mean_m: string,
         @Arg("location_region", () => String) location_region: string,
         @Arg("location_specific", () => String) location_specific: string,
+        @Arg("habitat_type", () => String) habitat_type: string,
+        @Arg("observation_month_begin", () => Int) observation_month_begin: number,
+        @Arg("observation_month_end", () => Int) observation_month_end: number,
+        @Arg("observation_year_begin", () => Int) observation_year_begin: number,
+        @Arg("observation_year_end", () => Int) observation_year_end: number,
+
+        //add observation_season
+        @Arg("observation_season", () => String) observation_season: string,
+
+        @Arg("analysis_number", () => String) analysis_number: string,
+
+        //add this section prey_kingdom through prey_scientific_name
         @Arg("prey_kingdom", () => String) prey_kingdom: string,
+        @Arg("prey_phylum", () => String) prey_phylum: string,
+        @Arg("prey_class", () => String) prey_class: string,
+        @Arg("prey_order", () => String) prey_order: string,
+        @Arg("prey_suborder", () => String) prey_suborder: string,
+        @Arg("prey_family", () => String) prey_family: string,
+        @Arg("prey_genus", () => String) prey_genus: string,
+        @Arg("prey_scientific_name", () => String) prey_scientific_name: string,
+
+        @Arg("inclusive_prey_taxon", () => String) inclusive_prey_taxon: string,
+
+        //add this section prey_name_ITIS_ID through prey_part
+        @Arg("prey_name_ITIS_ID", () => String) prey_name_ITIS_ID: string,
+        @Arg("prey_name_status", () => String) prey_name_status: string,
+        @Arg("prey_stage", () => String) prey_stage: string,
+        @Arg("prey_part", () => String) prey_part: string,
+
+        @Arg("prey_common_name", () => String) prey_common_name: string,
+        @Arg("fraction_diet", () => String) fraction_diet: string,
+        //add diet_type
         @Arg("diet_type", () => String) diet_type: string,
+        @Arg("item_sample_size", () => Int) item_sample_size: number,
+        @Arg("bird_sample_size", () => Int) bird_sample_size: number,
+        @Arg("sites", () => String) sites: string,
+        @Arg("study_type", () => String) study_type: string,
+        @Arg("notes", () => String) notes: string,
+        //add entered_by
+        @Arg("entered_by", () => String) entered_by: string,
+        @Arg("source", () => String) source: string,
+        @Arg("doi", () => String) doi: string,
+        @Arg("species", () => String) species: string,
+        @Arg("new_species", () => String) new_species: string,
+        @Arg("country", () => String) country: string,
+        @Arg("state_province", () => String) state_province: string,
+        @Arg("location_other", () => String) location_other: string,
+        @Arg("lat_long_yn", () => String) lat_long_yn: string,
+        @Arg("elevation_yn", () => String) elevation_yn: string,
+        @Arg("sex_yn", () => String) sex_yn: string,
+        @Arg("sex", () => String) sex: string,
+        @Arg("age_class", () => String) age_class: string,
+        @Arg("study_location", () => String) study_location: string,
+        @Arg("table_fig_number", () => String) table_fig_number: string,
+        @Arg("all_prey_diet_yn", () => String) all_prey_diet_yn: string,
         ) {
-            await AvianDietPending.insert({common_name,source,subspecies,taxonomy,location_region, location_specific,
-                 prey_kingdom,diet_type})
+            await AvianDietPending.insert({common_name,scientific_name,subspecies,family,taxonomy,longitude_dd,latitude_dd,altitude_min_m,altitude_max_m,altitude_mean_m,location_region,location_specific,habitat_type,
+                observation_month_begin,observation_month_end,observation_year_begin,observation_year_end,observation_season,analysis_number,prey_kingdom,prey_phylum,prey_class,prey_order,prey_suborder,prey_family,prey_genus,
+                prey_scientific_name,inclusive_prey_taxon,prey_name_ITIS_ID,prey_name_status,prey_stage,prey_part,prey_common_name,fraction_diet,diet_type,item_sample_size,bird_sample_size,sites,study_type,notes,entered_by,
+                source,doi,species,new_species,country,state_province,location_other,lat_long_yn,elevation_yn,sex_yn,sex,age_class,study_location,table_fig_number,all_prey_diet_yn})
             return true;
         }
 


### PR DESCRIPTION
Based on eden0606/submit-data-page branch, eden has 41 variables ( 4 of which will be merged into source). So she has 38 column names implemented. 14 of the columns she is implementing are new to the DB, I've added them through the workbench. I believe she is missing 18 columns  (I tried to comment which ones on the PendingPageResolver). Overall there are 57 columns/Fields in our table (1 is unique_id which we don't create). This means we will implement 56 columns in our mutation as of right now.

If the order of the arguments for the mutation looks weird to you, its cause it is. That's the order they are in the database (maybe we could change this in the future, but thats a style/look thing and its not our fault really).

I don't think we should merge this commit until Eden implements the additional columns on frontend. Plus, she might add more new columns to the database (depending on the rest of the form) meaning we need to add them to the db and change the mutation again.

Pich, as you can tell, its definitely bad/ugly practice to write out the args like this, hopefully we can figure out how to populate the mutation from the frontend with an inputtype/argtype...

**note the first commit was missing nullable:true on the field decorator for the new columns in the entity..that's why there is a second commit

**the spacing between args for the mutation is just so eden can see which columns she's missing, I'll remove it later